### PR TITLE
Upgrade libexpat in base stage to avoid stale symbol relocation (8.3-cli, 8.4-cli)

### DIFF
--- a/php/8.3-cli/Dockerfile
+++ b/php/8.3-cli/Dockerfile
@@ -14,6 +14,11 @@ ENV INI_REALPATH_CACHE_TTL "600"
 ENV INIT_MEMORY_LIMIT "512M"
 
 RUN set -ex \
+    # Keep libexpat in sync with the current Alpine repo. The upstream php base
+    # image can freeze an older libexpat whose soname is still satisfied, so a
+    # downstream "apk add python3/supervisor" pulls a newer pyexpat that then
+    # fails to relocate against the stale library at runtime.
+    && apk upgrade --no-cache libexpat \
     # Build dependencies
     && apk add --no-cache --virtual .build-deps  \
         $PHPIZE_DEPS \

--- a/php/8.4-cli/Dockerfile
+++ b/php/8.4-cli/Dockerfile
@@ -14,6 +14,11 @@ ENV INI_REALPATH_CACHE_TTL="600"
 ENV INI_MEMORY_LIMIT="512M"
 
 RUN set -ex \
+    # Keep libexpat in sync with the current Alpine repo. The upstream php base
+    # image can freeze an older libexpat whose soname is still satisfied, so a
+    # downstream "apk add python3/supervisor" pulls a newer pyexpat that then
+    # fails to relocate against the stale library at runtime.
+    && apk upgrade --no-cache libexpat \
     # Build dependencies
     && apk add --no-cache --virtual .build-deps  \
         $PHPIZE_DEPS \


### PR DESCRIPTION
## Problem

The 68publishers php images bake in whatever `libexpat` was current in the Alpine branch **at image build time**, and that library does not get re-synced afterwards. Meanwhile the Alpine release branch keeps publishing libexpat patch updates. The frozen `libexpat.so.1` soname still satisfies apk's dependency check, so a downstream `apk add python3` / `supervisor` pulls a **newer** `pyexpat` (built against the branch-current libexpat) without upgrading the stale library. At runtime pyexpat then fails to relocate:

```
ImportError: Error relocating .../pyexpat...so:
  XML_SetAllocTrackerActivationThreshold: symbol not found
```

(`XML_SetAllocTrackerActivationThreshold` was added in libexpat 2.7.2.) This crash-loops anything importing `pyexpat` — notably `supervisord`, breaking worker containers built on these images.

## Verified per image (`apk add supervisor` on the published `-cli-dev` tag, then `import pyexpat`)

| image | alpine | frozen libexpat | after supervisor install | pyexpat |
|-------|--------|-----------------|--------------------------|---------|
| 8.1-cli | 3.18.2 | 2.5.0 | upgraded to **2.7.0** | OK |
| 8.3-cli | 3.20.3 | 2.6.3 | stays **2.6.3** | **crash** |
| 8.4-cli | 3.21   | 2.7.0 | stays **2.7.0** | **crash** |

## Fix

Add `apk upgrade --no-cache libexpat` to the `base` stage of **8.3-cli** and **8.4-cli**. This resyncs libexpat to the branch-current `2.7.5` (which has the symbol). It adds no new packages — it only bumps one shared library — and because `dev`/`prod`/`prod-imagick` derive from `base`, every published tag inherits the fix.

## Scope and why not the others

- **8.1-cli (alpine 3.18):** not affected — apk already upgrades libexpat to the branch newest (2.7.0) while installing supervisor, and 3.18's python matches it. Note 3.18 caps at 2.7.0 (no symbol), so an upgrade could not help even hypothetically; the real remedy there would be a newer Alpine.
- **unit images:** run NGINX Unit (web), not supervisor-managed worker fleets, so they do not install python/supervisor.

## Constraint to be aware of

`apk upgrade` can only reach the newest version in the image's pinned Alpine branch. It works here because 3.20 and 3.21 both moved to 2.7.5. If a future need requires a version only available in `edge` (e.g. 2.8.x), the base image would have to be bumped to a newer Alpine (or the package pulled from another repo) rather than relying on this upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)